### PR TITLE
Fix allowedDevOrigins configuration to resolve cross-origin warning

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -13,9 +13,9 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
-  devIndicators: {
-    allowedDevOrigins: ['http://10.211.66.119'],
-  },
+  // Fix: allowedDevOrigins should be at top level, not under devIndicators
+  // and should specify hostname without protocol
+  allowedDevOrigins: ['10.211.66.119'],
   // The 'images' block should be here, at the top level
   images: { 
     unoptimized: true 


### PR DESCRIPTION
## Problem
The application was showing a cross-origin warning:
```
Cross origin request detected from 10.211.66.119 to /_next/* resource. In a future major version of Next.js, you will need to explicitly configure 'allowedDevOrigins' in next.config to allow this.
```

## Root Cause
The `allowedDevOrigins` configuration was incorrectly placed under `devIndicators` and included the protocol (`http://`) in the origin specification.

## Solution
Based on Next.js documentation research:
1. **Moved `allowedDevOrigins` to top level** of `next.config.js` (not under `devIndicators`)
2. **Removed protocol** from origin specification - should be just the hostname/IP
3. **Updated format** from `['http://10.211.66.119']` to `['10.211.66.119']`

## Changes
- ✅ Corrected `allowedDevOrigins` placement and syntax
- ✅ Removed the incorrectly nested `devIndicators.allowedDevOrigins` 
- ✅ Updated origin format to hostname-only specification

This change ensures the development server properly handles cross-origin requests from the specified IP address and eliminates the warning message.